### PR TITLE
Allow defining parameters in the extension configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ parameters:
   acme.foo: boo!
 ```
 
-Parameters defined in such a way are also available in ``behat.yml``:
+Defining parameters
+-------------------
+
+Parameters defined in imported files are also available in ``behat.yml``:
 
 ```yaml
 # behat.yml
@@ -73,5 +76,19 @@ default:
         - SearchContext:
             myFoo: %acme.foo%
   # ...
+```
+
+Furthermore, parameters can also be defined as part of extension's configuration directly in ``behat.yml``:
+
+```yaml
+# behat.yml
+default:
+  extensions:
+    Zalas\Behat\NoExtension:
+      parameters:
+        foo: bar
+        baz:
+          a: 1
+          b: bazinga!
 ```
 

--- a/features/defining_parameters.feature
+++ b/features/defining_parameters.feature
@@ -1,0 +1,131 @@
+Feature: Defining parameters
+  In order to avoid duplication in my configuration
+  I need to define parameters
+  As a Behat User
+
+  Scenario: Defining parameters
+    Given a behat configuration:
+    """
+    default:
+      suites:
+        acme:
+          contexts:
+            - FeatureContext:
+                answers: %answers%
+      extensions:
+        Zalas\Behat\NoExtension:
+          imports:
+            - features/bootstrap/config/services.yml
+    """
+    And a config file "features/bootstrap/config/services.yml":
+    """
+    parameters:
+      answers: {"a": "foo", "b": bazinga!}
+    """
+    And a context file "features/bootstrap/FeatureContext.php":
+    """
+    <?php
+
+    use Behat\Behat\Context\Context;
+
+    class FeatureContext implements Context
+    {
+        private $answers;
+        private $answer;
+
+        public function __construct($answers = null)
+        {
+            $this->answers = $answers;
+        }
+
+        /**
+         * @Given I select :answer
+         */
+        public function iSelect($answer)
+        {
+            $this->answer = $answer;
+        }
+
+        /**
+         * @Then I should see :message
+         */
+         public function iShouldSee($message)
+         {
+            if ($message !== $this->answers[$this->answer]) {
+                throw new \LogicException(sprintf('Expected "%s", but got "%s"', $message, $this->answers[$this->answer]));
+            }
+         }
+    }
+    """
+    And a feature file "features/my.feature":
+    """
+    Feature: My feature
+
+      Scenario:
+        Given I select "b"
+        Then I should see "bazinga!"
+    """
+    When I run behat
+    Then it should pass
+
+  Scenario: Defining parameters in behat.yml
+    Given a behat configuration:
+    """
+    default:
+      suites:
+        acme:
+          contexts:
+            - FeatureContext:
+                answers: %answers%
+      extensions:
+        Zalas\Behat\NoExtension:
+          parameters:
+            answers:
+              a: foo
+              b: bazinga!
+    """
+    And a context file "features/bootstrap/FeatureContext.php":
+    """
+    <?php
+
+    use Behat\Behat\Context\Context;
+
+    class FeatureContext implements Context
+    {
+        private $answers;
+        private $answer;
+
+        public function __construct($answers = null)
+        {
+            $this->answers = $answers;
+        }
+
+        /**
+         * @Given I select :answer
+         */
+        public function iSelect($answer)
+        {
+            $this->answer = $answer;
+        }
+
+        /**
+         * @Then I should see :message
+         */
+         public function iShouldSee($message)
+         {
+            if ($message !== $this->answers[$this->answer]) {
+                throw new \LogicException(sprintf('Expected "%s", but got "%s"', $message, $this->answers[$this->answer]));
+            }
+         }
+    }
+    """
+    And a feature file "features/my.feature":
+    """
+    Feature: My feature
+
+      Scenario:
+        Given I select "b"
+        Then I should see "bazinga!"
+    """
+    When I run behat
+    Then it should pass

--- a/src/ServiceContainer/NoExtension.php
+++ b/src/ServiceContainer/NoExtension.php
@@ -41,6 +41,7 @@ class NoExtension implements Extension
     {
         $config = $builder->children();
         $config->arrayNode('imports')->prototype('scalar');
+        $config->arrayNode('parameters')->prototype('variable');
     }
 
     /**
@@ -55,6 +56,10 @@ class NoExtension implements Extension
 
         foreach ($config['imports'] as $file) {
             $yamlLoader->load($file);
+        }
+
+        foreach ($config['parameters'] as $name => $value) {
+            $container->setParameter($name, $value);
         }
     }
 


### PR DESCRIPTION
Parameters defined in imported files are already available in `behat.yml`. This feature allows defining parameters directly in the extension configuration:

``` yaml
# behat.yml
default:
  extensions:
    Zalas\Behat\NoExtension:
      parameters:
        foo: bar
        baz:
          a: 1
          b: bazinga!
```
