### PR TITLE
Injecting services into contexts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.php_cs.cache
 /bin/
 /composer.lock
 /vendor/

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,34 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(['src'])
+;
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@PSR2' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'blank_line_before_statement' => true,
+        'declare_strict_types' => true,
+        'native_function_invocation' => true,
+        'no_empty_comment' => true,
+        'no_empty_phpdoc' => true,
+        'no_empty_statement' => true,
+        'no_extra_blank_lines' => true,
+        'no_extra_consecutive_blank_lines' => true,
+        'no_leading_import_slash' => true,
+        'no_leading_namespace_whitespace' => true,
+        'no_unused_imports' => true,
+        'no_useless_else' => true,
+        'ordered_class_elements' => true,
+        'ordered_imports' => true,
+        'phpdoc_add_missing_param_annotation' => ['only_untyped' => true],
+        'protected_to_private' => true,
+        'strict_comparison' => true,
+        'ternary_operator_spaces' => true,
+        'ternary_to_null_coalescing' => true,
+        'yoda_style' => true,
+    ])
+    ->setFinder($finder)
+;
+

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -7,8 +7,7 @@ build:
     project_setup:
     tests:
         override:
-            - ./vendor/bin/phpspec run --format=dot
-            - ./vendor/bin/behat --format=progress
+            - make test
 
 filter:
     paths: [src/*]

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ matrix:
 
 before_script:
   - if [[ "$(php --version | grep -cim1 xdebug)" -ge 1 ]]; then phpenv config-rm xdebug.ini; fi
-  - if [[ ! $deps || $deps = high ]]; then composer install; else composer update --prefer-lowest --prefer-stable; fi
+  - if [[ $deps = low ]]; then make update-min; else make install; fi
 
 script:
-  - ./vendor/bin/phpspec run --format=dot
-  - ./vendor/bin/behat --format=progress
+  - if [[ $deps = low ]]; then make test-min; else make test; fi

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+default: build
+
+build: install test
+.PHONY: build
+
+install:
+	composer install
+.PHONY: install
+
+update:
+	composer update
+.PHONY: update
+
+update-min:
+	composer update --prefer-stable --prefer-lowest
+.PHONY: update-min
+
+test: vendor cs phpspec behat
+.PHONY: test
+
+test-min: update-min cs phpspec behat
+.PHONY: test-min
+
+cs: vendor/bin/php-cs-fixer
+	vendor/bin/php-cs-fixer --dry-run --allow-risky=yes --no-interaction --ansi fix
+.PHONY: cs
+
+cs-fix: vendor/bin/php-cs-fixer
+	vendor/bin/php-cs-fixer --allow-risky=yes --no-interaction --ansi fix
+.PHONY: cs-fix
+
+phpspec: vendor/bin/phpspec
+	vendor/bin/phpspec run --format=dot
+.PHONY: phpunit
+
+behat: vendor/bin/behat
+	vendor/bin/behat --format=progress
+.PHONY: phpunit
+
+tools: vendor/bin/php-cs-fixer
+.PHONY: tools
+
+vendor: install
+
+vendor/bin/behat: install
+
+vendor/bin/phpspec: install
+
+vendor/bin/php-cs-fixer:
+	curl -Ls http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar -o vendor/bin/php-cs-fixer && chmod +x vendor/bin/php-cs-fixer

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,9 @@
     "require-dev": {
         "phpspec/phpspec": "^4.3",
         "bossa/phpspec2-expect": "^3.0",
-        "symfony/process": "^4.0",
-        "symfony/filesystem": "^4.0"
+        "symfony/process": "^3.3||^4.0",
+        "symfony/filesystem": "^3.3||^4.0",
+        "sebastian/comparator": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,11 @@
             "Zalas\\Behat\\NoExtension\\": "src"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "spec\\Zalas\\Behat\\NoExtension\\": "spec"
+        }
+    },
     "authors": [
         {
             "name": "Jakub Zalas",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "license": "MIT",
     "require": {
         "php": "^7.1",
-        "behat/behat": "^3.0"
+        "behat/behat": "^3.0",
+        "symfony/dependency-injection": "^3.3||^4.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^4.3",

--- a/features/bootstrap/BehatRunnerContext.php
+++ b/features/bootstrap/BehatRunnerContext.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\PyStringNode;

--- a/features/injecting_services_into_contexts.feature
+++ b/features/injecting_services_into_contexts.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Injecting services into contexts
   In order to make the maintenance of my contexts easier
   I need to delegate creation of context dependencies

--- a/features/injecting_services_into_contexts.feature
+++ b/features/injecting_services_into_contexts.feature
@@ -1,0 +1,81 @@
+@wip
+Feature: Injecting services into contexts
+  In order to make the maintenance of my contexts easier
+  I need to delegate creation of context dependencies
+  As a Behat User
+
+  Background:
+    Given a behat configuration:
+    """
+    default:
+      extensions:
+        Zalas\Behat\NoExtension:
+          argument_resolver: true
+          imports:
+            - features/bootstrap/config/services.yml
+    """
+    And "Acme" classes are autoloaded from "features/bootstrap/Acme"
+
+  Scenario: Service class name matches the argument's type hint
+    Given a config file "features/bootstrap/config/services.yml":
+    """
+    services:
+      Acme\Foo:
+        public: true
+    """
+    And a class file "features/bootstrap/Acme/Foo.php":
+    """
+    <?php
+
+    namespace Acme;
+
+    class Foo
+    {
+        public function useIt() {}
+    }
+    """
+    And a context file "features/bootstrap/FeatureContext.php":
+    """
+    <?php
+
+    use Acme\Foo;
+    use Behat\Behat\Context\Context;
+
+    class FeatureContext implements Context
+    {
+        private $foo;
+
+        public function __construct(Foo $foo = null)
+        {
+            $this->foo = $foo;
+        }
+
+        /**
+         * @Given my service was injected to the context file
+         */
+        public function myServiceWasInjectedToTheContextFile()
+        {
+            if (!$this->foo instanceof Foo) {
+                throw new \LogicException('Expected instance of Acme\Foo');
+            }
+        }
+
+        /**
+         * @Then I should be able to use it
+         */
+         public function iShouldBeAbleToUseIt()
+         {
+             $this->foo->useIt();
+         }
+    }
+    """
+    And a feature file "features/my.feature":
+    """
+    Feature: My feature
+
+      Scenario:
+        Given my service was injected to the context file
+        Then I should be able to use it
+    """
+    When I run behat
+    Then it should pass

--- a/spec/Context/Argument/Fixtures/Bar.php
+++ b/spec/Context/Argument/Fixtures/Bar.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace spec\Zalas\Behat\NoExtension\Context\Argument\Fixtures;
+
+class Bar
+{
+}

--- a/spec/Context/Argument/Fixtures/Foo.php
+++ b/spec/Context/Argument/Fixtures/Foo.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace spec\Zalas\Behat\NoExtension\Context\Argument\Fixtures;
+
+class Foo
+{
+    public function __construct(string $a, string $b, Bar $bar)
+    {
+    }
+}

--- a/spec/Context/Argument/Fixtures/FooWithNoConstructor.php
+++ b/spec/Context/Argument/Fixtures/FooWithNoConstructor.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace spec\Zalas\Behat\NoExtension\Context\Argument\Fixtures;
+
+class FooWithNoConstructor
+{
+}

--- a/spec/Context/Argument/ServiceArgumentResolverSpec.php
+++ b/spec/Context/Argument/ServiceArgumentResolverSpec.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace spec\Zalas\Behat\NoExtension\Context\Argument;
+
+use Behat\Behat\Context\Argument\ArgumentResolver;
+use PhpSpec\ObjectBehavior;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use ReflectionClass;
+use RuntimeException;
+use spec\Zalas\Behat\NoExtension\Context\Argument\Fixtures\Bar;
+use spec\Zalas\Behat\NoExtension\Context\Argument\Fixtures\Foo;
+use spec\Zalas\Behat\NoExtension\Context\Argument\Fixtures\FooWithNoConstructor;
+
+class ServiceArgumentResolverSpec extends ObjectBehavior
+{
+    function let(ContainerInterface $container)
+    {
+        $this->beConstructedWith($container);
+    }
+
+    function it_is_an_argument_resolver()
+    {
+        $this->shouldHaveType(ArgumentResolver::class);
+    }
+
+    function it_ignores_classes_with_no_constructors()
+    {
+        $class = new ReflectionClass(FooWithNoConstructor::class);
+
+        $this->resolveArguments($class, ['a', 'b', 'c'])->shouldReturn(['a', 'b', 'c']);
+    }
+
+    function it_replaces_the_argument_if_it_is_found_in_container_by_type(ContainerInterface $container, Bar $bar)
+    {
+        $container->has(Bar::class)->willReturn(true);
+        $container->get(Bar::class)->willReturn($bar);
+
+        $class = new ReflectionClass(Foo::class);
+
+        $this->resolveArguments($class, ['a', 'b', 'c'])->shouldReturn(['a', 'b', $bar]);
+    }
+
+    function it_does_not_replace_an_argument_if_service_is_not_found_in_the_container(ContainerInterface $container, Bar $bar)
+    {
+        $container->has(Bar::class)->willReturn(false);
+        $container->get(Bar::class)->willThrow(new class extends RuntimeException implements NotFoundExceptionInterface {
+        });
+
+        $class = new ReflectionClass(Foo::class);
+
+        $this->resolveArguments($class, ['a', 'b', 'c'])->shouldReturn(['a', 'b', 'c']);
+    }
+}

--- a/spec/ServiceContainer/NoExtensionSpec.php
+++ b/spec/ServiceContainer/NoExtensionSpec.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace spec\Zalas\Behat\NoExtension\ServiceContainer;
 

--- a/src/Context/Argument/ServiceArgumentResolver.php
+++ b/src/Context/Argument/ServiceArgumentResolver.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace Zalas\Behat\NoExtension\Context\Argument;
+
+use Behat\Behat\Context\Argument\ArgumentResolver;
+use Psr\Container\ContainerInterface;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * Resolves context arguments with services found in a psr container.
+ */
+final class ServiceArgumentResolver implements ArgumentResolver
+{
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    public function resolveArguments(ReflectionClass $classReflection, array $arguments): array
+    {
+        if ($constructor = $classReflection->getConstructor()) {
+            return $this->resolveConstructorArguments($constructor, $arguments);
+        }
+
+        return $arguments;
+    }
+
+    private function resolveConstructorArguments(ReflectionMethod $constructor, array $arguments): array
+    {
+        $constructorParameters = $constructor->getParameters();
+
+        foreach ($constructorParameters as $position => $parameter) {
+            if ($parameter->getClass() && $service = $this->resolve($parameter->getClass())) {
+                $arguments[$position] = $service;
+            }
+        }
+
+        return $arguments;
+    }
+
+    private function resolve(ReflectionClass $class)
+    {
+        if ($this->container->has($class->getName())) {
+            return $this->container->get($class->getName());
+        }
+    }
+}

--- a/src/ServiceContainer/NoExtension.php
+++ b/src/ServiceContainer/NoExtension.php
@@ -1,63 +1,72 @@
 <?php
+declare(strict_types=1);
 
 namespace Zalas\Behat\NoExtension\ServiceContainer;
 
 use Behat\Testwork\ServiceContainer\Extension;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
+use Zalas\Behat\NoExtension\Context\Argument\ServiceArgumentResolver;
 
 class NoExtension implements Extension
 {
-    /**
-     * {@inheritdoc}
-     */
     public function process(ContainerBuilder $container)
     {
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getConfigKey()
     {
         return 'no';
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function initialize(ExtensionManager $extensionManager)
     {
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function configure(ArrayNodeDefinition $builder)
     {
         $config = $builder->children();
         $config->arrayNode('imports')->prototype('scalar');
         $config->arrayNode('parameters')->prototype('variable');
+        $config->booleanNode('argument_resolver');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function load(ContainerBuilder $container, array $config)
+    {
+        $this->loadImports($container, $config);
+        $this->loadParameters($container, $config);
+        $this->loadArgumentResolver($container, $config);
+    }
+
+    private function loadImports(ContainerBuilder $container, array $config): void
     {
         $basePath = $container->getParameter('paths.base');
         $yamlLoader = new YamlFileLoader($container, new FileLocator($basePath));
 
         foreach ($config['imports'] as $file) {
-            $file = str_replace('%paths.base%', $basePath, $file);
+            $file = \str_replace('%paths.base%', $basePath, $file);
             $yamlLoader->load($file);
         }
+    }
 
+    private function loadParameters(ContainerBuilder $container, array $config): void
+    {
         foreach ($config['parameters'] as $name => $value) {
             $container->setParameter($name, $value);
+        }
+    }
+
+    private function loadArgumentResolver(ContainerBuilder $container, array $config): void
+    {
+        if ($config['argument_resolver']) {
+            $container->register(ServiceArgumentResolver::class)
+                ->addArgument(new Reference(ContainerInterface::class))
+                ->addTag('context.argument_resolver');
         }
     }
 }


### PR DESCRIPTION
Fixes #9 

The argument resolver needs to be explicitly enabled in `behat.yml`:

```yaml
default:
    extensions:
        Zalas\Behat\NoExtension:
            argument_resolver: true
            imports:
                - features/bootstrap/config/services.yml
```


Given a config file "features/bootstrap/config/services.yml":

```yaml
services:
    Acme\Foo:
        public: true
```

And a service `Acme\Foo`:

```php
namespace Acme;

class Foo
{
}
```

The service should be injected into the context class:

```php
use Acme\Foo;
use Behat\Behat\Context\Context;

class FeatureContext implements Context
{
    private $foo;

    public function __construct(Foo $foo)
    {
        $this->foo = $foo;
    }
}
```


Autowiring will work as well:

```yaml
services:

    Acme\:
        resource: '../Acme'
        public: true
        autowire: true
```